### PR TITLE
Support react-native 0.60+ and bug fixes (#194)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,25 +2,23 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0'
-
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
+        classpath 'com.android.tools.build:gradle:3.3.2'
     }
 }
 
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "25.0.0"
+    compileSdkVersion 28
+    buildToolsVersion "28.0.3"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion 28
         versionCode 1
     }
     lintOptions {
@@ -30,11 +28,12 @@ android {
 
 repositories {
     mavenCentral()
+    google()
     jcenter()
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
-    compile 'com.facebook.fresco:fresco:0.11.0'
-    compile 'me.relex:photodraweeview:1.0.0'
+    implementation 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.fresco:fresco:1.12.1'
+    implementation 'me.relex:photodraweeview:1.1.3'
 }

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -7,8 +7,8 @@
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
 
     <uses-sdk
-        android:minSdkVersion="16"
-        android:targetSdkVersion="22" />
+        android:minSdkVersion="18"
+        android:targetSdkVersion="28" />
 
     <application
       android:name=".MainApplication"

--- a/ios/RNPhotoView.m
+++ b/ios/RNPhotoView.m
@@ -140,6 +140,7 @@
 #pragma mark - Setup
 
 - (CGFloat)initialZoomScaleWithMinScale {
+    CGFloat minZoom = self.minimumZoomScale;
     CGFloat zoomScale = self.minimumZoomScale;
     if (_photoImageView) {
         // Zoom image to fill if the aspect ratios are fairly similar
@@ -153,7 +154,7 @@
         if (ABS(boundsAR - imageAR) < 0.17) {
             zoomScale = MAX(xScale, yScale);
             // Ensure we don't zoom in or out too far, just in case
-            zoomScale = MIN(MAX(self.minimumZoomScale, zoomScale), self.maximumZoomScale);
+            zoomScale = MIN(MAX(minZoom, zoomScale), minZoom);
         }
     }
     return zoomScale;
@@ -295,7 +296,7 @@
         }
         _source = source;
         NSURL *imageURL = [NSURL URLWithString:uri];
-        
+
         if (![[uri substringToIndex:4] isEqualToString:@"http"]) {
             @try {
                 UIImage *image = RCTImageFromLocalAssetURL(imageURL);
@@ -316,10 +317,10 @@
         }
 
         NSURLRequest *request = [[NSURLRequest alloc] initWithURL:imageURL];
-        
+
         if (source[@"headers"]) {
             NSMutableURLRequest *mutableRequest = [request mutableCopy];
-            
+
             NSDictionary *headers = source[@"headers"];
             NSEnumerator *enumerator = [headers keyEnumerator];
             id key;
@@ -334,7 +335,7 @@
         }
 
         // use default values from [imageLoader loadImageWithURLRequest:request callback:callback] method
-        [_bridge.imageLoader loadImageWithURLRequest:request
+        [[_bridge moduleForClass:[RCTImageLoader class]] loadImageWithURLRequest:request
                                         size:CGSizeZero
                                        scale:1
                                      clipped:YES

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,41 @@
 {
   "name": "react-native-photo-view",
-  "version": "1.4.0",
+  "version": "1.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "node": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/node/-/node-8.3.0.tgz",
-      "integrity": "sha512-RU3iQgXeDBU45dv6BrfDrgTyUjJk1yorN64l0sce+E+2pZzFbRbBicPMBD/hWjo0GSMnA5a+RwFtWwHNDlojaw==",
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "requires": {
-        "node-bin-setup": "1.0.6"
+        "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
-    "node-bin-setup": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/node-bin-setup/-/node-bin-setup-1.0.6.tgz",
-      "integrity": "sha512-uPIxXNis1CRbv1DwqAxkgBk5NFV3s7cMN/Gf556jSw6jBvV7ca4F9lRL/8cALcZecRibeqU+5dFYqFFmzv5a0Q=="
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "prop-types": {
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
+      }
+    },
+    "react-is": {
+      "version": "16.10.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.2.tgz",
+      "integrity": "sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-photo-view",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Displaying photos with pinch-to-zoom",
   "main": "index.js",
   "author": {

--- a/react-native-photo-view.podspec
+++ b/react-native-photo-view.podspec
@@ -6,12 +6,12 @@ Pod::Spec.new do |s|
   s.name         = "react-native-photo-view"
   s.version      = package["version"]
   s.summary      = package['description']
-  s.author       = package['author'] 
+  s.author       = package['author']
   s.homepage     = package['homepage']
   s.license      = package['license']
   s.ios.deployment_target = "7.0"
   s.tvos.deployment_target = "9.0"
   s.source       = { :git => "https://github.com/alwx/react-native-photo-view.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/*.{h,m}"
-  s.dependency "React"
+  s.dependency "React-Core"
 end


### PR DESCRIPTION
* Fix android build warning.

* Fix gradle build.

* Fix photodraweeview version.

* rollback photodraweeview version.

* Update photodraweeview:1.1.3

* replaced deprecated bridge.imageLoader calls with moduleForClass API

* Rollback minSdkVersion.

* fix: Xcode 12 compatibility