### PR TITLE
upgrading the photodraweeview version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,5 +40,5 @@ repositories {
 dependencies {
     implementation 'com.facebook.react:react-native:+'
     implementation 'com.facebook.fresco:fresco:1.12.1'
-    implementation 'me.relex:photodraweeview:1.1.3'
+    implementation 'me.relex:photodraweeview:2.1.0'
 }


### PR DESCRIPTION
upgrading the photodraweeview version from 1.1.3 to 2.1.0 to make it compatible for android 34 upgrade 